### PR TITLE
Add company research and lead generation skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Connect AI assistants to Exa's API skills: search, contents extraction, answer, 
 | `build-with-exa` | Build applications and agents with Exa's API Platform: search, contents extraction, answer, context, Agent API, monitors, websets, OpenAI-compatible endpoints, and `exa-py` / `exa-js`. |
 | `exa-search` | Call Exa Search directly with cURL or raw HTTP for semantic web search, ranked results, content extraction, structured output, filters, freshness, and streaming search responses. |
 | `exa-contents` | Call Exa Contents directly with cURL or raw HTTP for extracted text, highlights, summaries, links, image links, subpages, and freshness-controlled crawling from known URLs. |
+| `company-research` | Research companies, competitors, funding, news, leadership, and market context with Exa Agent and advanced search. |
+| `lead-generation` | Generate enriched ICP-based lead lists with Exa Agent, including structured scoring and CSV output. |
 
 ## Installation
 

--- a/skills/company-research/SKILL.md
+++ b/skills/company-research/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: company-research
+description: Company research using Exa. Finds company info, competitors, news, financials, LinkedIn profiles, builds company lists. Use when researching companies, doing competitor analysis, market research, or building company lists.
+context: fork
+---
+
+# Company Research
+
+## Tool Selection (Critical)
+
+Two Exa surfaces, two jobs:
+
+- **Exa Agent** (`agent_create_run` / `agent_wait_for_run` / `agent_get_run_output`) — the default for company research. Use it for deep dives, competitor analysis, multi-angle research (product + funding + news + people), and building company lists. One Agent run handles query decomposition, multi-step searching, and synthesis internally — do not orchestrate many manual searches for work an Agent run covers.
+- **`web_search_advanced_exa`** — quick, low-latency lookups: a fast `category: "company"` discovery pass, a single news check, or finding a homepage.
+
+Do NOT use other Exa tools.
+
+## Deep Dives and Lists: Exa Agent
+
+Agent runs are async: create the run, wait for it, then read the output.
+
+1. `agent_create_run` with a natural-language `query` and, when you want repeatable structure, an `outputSchema` (bound arrays with `maxItems`). Returns an `agent_run_...` ID.
+2. `agent_wait_for_run` until the run is `completed` (call again if still running).
+3. `agent_get_run_output` — read `output.text` or `output.structured`, plus `output.grounding` citations.
+
+Useful inputs: `systemPrompt` (source preferences, dedup rules), `input.exclusion` (companies to avoid), `previousRunId` (follow-up runs), `effort` (`"auto"` default; `"high"` for hard research).
+
+### Example: company deep dive
+
+```
+agent_create_run {
+  "query": "Research Anthropic: product lines, funding history and valuation, key executives, main competitors, and notable news from the last 6 months.",
+  "effort": "auto",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "overview": { "type": "string" },
+      "funding": { "type": "array", "maxItems": 10, "items": { "type": "object", "properties": { "round": { "type": "string" }, "amount": { "type": "string" }, "date": { "type": "string" } }, "required": ["round"] } },
+      "competitors": { "type": "array", "maxItems": 10, "items": { "type": "string" } },
+      "key_people": { "type": "array", "maxItems": 10, "items": { "type": "object", "properties": { "name": { "type": "string" }, "title": { "type": "string" } }, "required": ["name", "title"] } }
+    },
+    "required": ["overview", "competitors"]
+  }
+}
+```
+
+### Example: build a company list
+
+```
+agent_create_run {
+  "query": "Find 25 AI infrastructure startups headquartered in San Francisco. For each, include what they build and their latest funding stage.",
+  "effort": "auto",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "companies": {
+        "type": "array",
+        "maxItems": 25,
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "website": { "type": "string", "format": "uri" },
+            "description": { "type": "string", "description": "in 12 words or less" },
+            "funding_stage": { "type": "string" }
+          },
+          "required": ["name", "website", "description"]
+        }
+      }
+    },
+    "required": ["companies"]
+  }
+}
+```
+
+## Quick Lookups: Advanced Search
+
+Use `web_search_advanced_exa` when a single fast search answers the question. Tune `numResults` to intent (a few → 10-20; comprehensive → 50-100; specified → match it).
+
+### Categories
+
+- `company` → homepages, rich metadata (headcount, location, funding, revenue)
+- `news` → press coverage, announcements
+- `people` → public professional profiles
+- No category (`type: "auto"`) → general web results, broader context
+
+Default to `type: "auto"`. Prefer `highlights` for content extraction; do not stack text + highlights + summary in one call.
+
+### Category-Specific Filter Restrictions
+
+Unsupported category/filter combinations return 400 errors:
+
+- `category: "company"` does not support published-date or crawl-date filters, `excludeDomains`, or exact-text filters; express constraints like "founded after 2020" in the query instead
+- `category: "people"` does not support published-date, crawl-date, domain, or exact-text filters; put all filtering in the natural-language query
+- Without a category (or with `news`), domain and date filters work fine
+
+### Examples
+
+Discovery pass:
+```
+web_search_advanced_exa {
+  "query": "AI infrastructure startups San Francisco",
+  "category": "company",
+  "numResults": 20,
+  "type": "auto"
+}
+```
+
+News check:
+```
+web_search_advanced_exa {
+  "query": "Anthropic AI safety",
+  "category": "news",
+  "numResults": 15,
+  "startPublishedDate": "2025-01-01"
+}
+```
+
+Key people:
+```
+web_search_advanced_exa {
+  "query": "VP Engineering AI infrastructure",
+  "category": "people",
+  "numResults": 20
+}
+```
+
+## Token Isolation
+
+Never dump raw search results into main context. Spawn Task agents for Advanced Search calls; for Agent runs, go straight from `output.structured` to the final answer.
+
+## Browser Fallback
+
+Fall back to Claude in Chrome only when content is auth-gated or requires JavaScript rendering.
+
+## Output Format
+
+Return:
+1) Results (structured list; one company per row)
+2) Sources (URLs; 1-line relevance each — use `output.grounding` from Agent runs)
+3) Notes (uncertainty/conflicts)
+
+## References
+
+- Exa Agent guide: https://docs.exa.ai/reference/agent-api-guide
+- Company Search reference: https://docs.exa.ai/reference/verticals/company-for-coding-agents
+- Exa MCP setup: https://docs.exa.ai/reference/exa-mcp
+- Full docs for LLMs: https://docs.exa.ai/llms.txt

--- a/skills/lead-generation/SKILL.md
+++ b/skills/lead-generation/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: lead-generation
+description: Generate enriched lead lists using Exa Agent. Finds companies matching an ICP, enriches with signals/news/scores, and outputs CSV. Use when generating leads, building prospect lists, finding companies to sell to, doing outbound research, or ICP-based company discovery. Triggers on "leads", "lead gen", "prospect list", "find companies", "ICP", "outbound list".
+---
+
+# Lead Generation with Exa Agent
+
+Generate enriched lead lists using the Exa Agent API. An Agent run is an asynchronous, multi-step web research task: you describe the list you want plus an output schema, and Exa handles query decomposition, searching, verification, enrichment, and structured output internally. You do NOT need to orchestrate parallel searches, subagents, or manual deduplication.
+
+For very large or continuously maintained lead lists with per-item verification, consider Exa Websets instead: https://docs.exa.ai/websets/api/overview
+
+## Prerequisites
+
+This skill requires the Exa MCP server with the Agent tools enabled (`agent_tools`): `agent_create_run`, `agent_wait_for_run`, `agent_get_run_output`, `agent_cancel_run`.
+
+If the Agent tools are not available, tell the user:
+
+> You need the Exa MCP server installed with the Agent tools and your API key.
+> Instructions: https://docs.exa.ai/reference/exa-mcp
+
+Then stop.
+
+## Tool Restriction
+
+Use the Exa Agent tools (`agent_create_run`, `agent_wait_for_run`, `agent_get_run_output`, `agent_cancel_run`), plus Write and Bash (for CSV output). Do NOT use generic web search for the lead list itself.
+
+## Workflow
+
+```
+1. Confirm the ICP with the user (one small Agent run if research is needed)
+2. Create the lead-gen Agent run(s) with an outputSchema
+3. Wait for completion (agent_wait_for_run)
+4. Read output.structured (agent_get_run_output)
+5. Write the CSV
+6. Optional: expand with follow-up runs (previousRunId + input.exclusion)
+```
+
+## Step 1: Understand the ICP
+
+When the user says something like "Make a list of 200 leads for [company]", first establish the Ideal Customer Profile. If the user already described the ICP, confirm it. If not, run one small Agent run to research it:
+
+```
+agent_create_run {
+  "query": "Research {company_name}: what they sell, who their existing customers are, and what their ideal customer profile is.",
+  "effort": "low",
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "company_description": { "type": "string", "description": "What the company does in 2 sentences or less" },
+      "icp_description": { "type": "string", "description": "Concise ICP description that clearly defines target companies" },
+      "sub_verticals": { "type": "array", "maxItems": 10, "items": { "type": "string" }, "description": "Sub-verticals breaking down the ICP" },
+      "useful_enrichments": { "type": "array", "maxItems": 8, "items": { "type": "string" }, "description": "Enrichment columns useful for filtering high-signal companies" }
+    },
+    "required": ["company_description", "icp_description", "sub_verticals", "useful_enrichments"]
+  }
+}
+```
+
+Present the ICP to the user and confirm:
+
+- Is the ICP description accurate?
+- Any companies to exclude (competitors, existing customers)?
+- How many leads do they want? (default 200)
+- Any specific enrichment columns they care about?
+
+## Step 2: Create the Lead-Gen Run
+
+Design an `outputSchema` with a bounded `companies` array. Keep schemas small, flat, and explicit; always bound arrays with `maxItems`.
+
+**Core fields to always include:**
+
+- `company_name` (string)
+- `website` (string)
+- `product_description` (string, "in 12 words or less")
+- `icp_fit_score` (integer, 1-10)
+- `icp_fit_reasoning` (string, "compelling one-liner in 20 words or less")
+
+Add enrichment fields tailored to the campaign (funding stage, headcount range, headquarters, hiring signals, etc.). Give string fields a length hint in their description to keep CSV output clean.
+
+Use the run inputs for the pieces the old manual pipeline handled by hand:
+
+- `query` — describe the list: the ICP, geography, stage, and how many companies you want
+- `outputSchema` — the exact structure back, with `maxItems` bounding the companies array
+- `systemPrompt` — scoring rules, source preferences, dedup/exclusion emphasis
+- `input.exclusion` — companies to avoid (competitors, existing customers, results from earlier runs)
+- `effort` — `"auto"` by default; `"high"` or `"xhigh"` for large or hard lists
+
+Example:
+
+```
+agent_create_run {
+  "query": "Find 100 companies matching this ICP: {icp_description}. Prioritize {sub_verticals}. For each company, score ICP fit 1-10 for {user_company}.",
+  "effort": "auto",
+  "systemPrompt": "Prefer official company sites and recent funding announcements. Do not include duplicates or subsidiaries of the same parent company.",
+  "input": {
+    "exclusion": ["{competitor_1}", "{existing_customer_1}"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "companies": {
+        "type": "array",
+        "maxItems": 100,
+        "items": {
+          "type": "object",
+          "properties": {
+            "company_name": { "type": "string" },
+            "website": { "type": "string", "format": "uri" },
+            "product_description": { "type": "string", "description": "in 12 words or less" },
+            "icp_fit_score": { "type": "integer", "description": "1-10" },
+            "icp_fit_reasoning": { "type": "string", "description": "one-liner in 20 words or less" }
+          },
+          "required": ["company_name", "website", "product_description", "icp_fit_score", "icp_fit_reasoning"]
+        }
+      }
+    },
+    "required": ["companies"]
+  }
+}
+```
+
+`agent_create_run` returns an `agent_run_...` ID immediately. Save it.
+
+## Step 3: Wait and Read Output
+
+1. Call `agent_wait_for_run` with the run ID. It polls until the run reaches a terminal status (`completed`, `failed`, or `cancelled`) or times out — call it again if the run is still going.
+2. When `completed`, call `agent_get_run_output`. Read the companies from `output.structured`, citations from `output.grounding`, and the run cost from `costDollars`.
+
+Do not paste the full raw output into the conversation — go straight to CSV.
+
+## Step 4: Write the CSV
+
+Write `output.structured.companies` to `{target_company}_leads_{YYYY-MM-DD}.csv`, sorted by `icp_fit_score` descending. Join any array fields with " | ". Use Python's `csv.writer` (handles quoting/escaping) via Bash, or Write directly for small lists.
+
+Print a summary:
+
+```
+## Lead Generation Complete
+
+- Total leads: {count}
+- ICP score distribution: 8-10: {N} | 5-7: {N} | 1-4: {N}
+- Run ID: {agent_run_id}
+- Cost: ${costDollars}
+- Output: {filename}
+```
+
+## Step 5: Expanding the List
+
+If the user wants more leads than one run returned:
+
+- Create a follow-up run with `previousRunId` set to the completed run's ID, asking for additional companies
+- Put the company names already collected into `input.exclusion` so the new run avoids them
+- Append the new results to the CSV and re-deduplicate by normalized company name (strip "Inc"/"Ltd"/etc., case-insensitive)
+
+For lists in the many hundreds, run a few runs sequentially this way rather than one giant run, and confirm scope with the user first: "This will require ~{N} Agent runs. Proceed?"
+
+## Handling Failures
+
+- If a run ends `failed`, read the error from `agent_get_run_output`, adjust the query or schema, and retry once with different wording
+- Use `agent_cancel_run` if a run is clearly researching the wrong thing
+- If results are consistently below the requested count, narrow the ICP into 2-3 sub-vertical runs instead of one broad run
+
+## MCP Configuration
+
+Requires an Exa API key. Get yours at https://dashboard.exa.ai/api-keys
+
+```json
+{
+  "servers": {
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp?tools=agent_tools",
+      "headers": {
+        "x-api-key": "YOUR_EXA_API_KEY"
+      }
+    }
+  }
+}
+```
+
+## References
+
+- Exa Agent guide: https://docs.exa.ai/reference/agent-api-guide
+- Exa MCP setup: https://docs.exa.ai/reference/exa-mcp
+- Websets (verified list-building at scale): https://docs.exa.ai/websets/api/overview
+- Full docs for LLMs: https://docs.exa.ai/llms.txt


### PR DESCRIPTION
## Summary

Adds two Exa Agent workflow skills:

- `company-research` for company deep dives, competitor analysis, and company-list research
- `lead-generation` for ICP-based prospect discovery, enrichment, scoring, and CSV output

Updates the README Available Skills table accordingly.
