### PR TITLE
Update fake 'failed' URL in skills

### DIFF
--- a/skills/build-with-exa/references/contents.md
+++ b/skills/build-with-exa/references/contents.md
@@ -111,7 +111,7 @@ The contents endpoint can return HTTP 200 even when some requested URLs fail. Al
   ],
   "statuses": [
     { "id": "https://example.com", "status": "success" },
-    { "id": "https://bad.example", "status": "error" }
+    { "id": "https://failed-url.example.com", "status": "error" }
   ]
 }
 ```

--- a/skills/exa-contents/SKILL.md
+++ b/skills/exa-contents/SKILL.md
@@ -153,7 +153,7 @@ curl -sS -X POST "https://api.exa.ai/contents" \
   -H "Content-Type: application/json" \
   -H "x-api-key: $EXA_API_KEY" \
   -d '{
-    "urls": ["https://example.com", "https://bad.example"],
+    "urls": ["https://example.com", "https://failed-url.example.com"],
     "highlights": true
   }' | jq '{results, statuses}'
 ```


### PR DESCRIPTION
updates example failed URLs in the documentation from `https://bad.example` to `https://failed-url.example.com`